### PR TITLE
url保留字转义

### DIFF
--- a/type_builder_md.go
+++ b/type_builder_md.go
@@ -84,6 +84,7 @@ func escape(txt string) string {
 // url保留字转义
 func preprocessURL(urlStr string) string {
 	urlStr = strings.ReplaceAll(urlStr, "&reg", "&&#114;eg")
+	urlStr = strings.ReplaceAll(urlStr, "&para", "&&#112;ara")
 	return urlStr
 }
 


### PR DESCRIPTION
url 参数有类似这种参数时，&param={"version":"8.8.7"}，&para 会被转成¶