### PR TITLE
fix: add markdown/input/button component unmarshal case

### DIFF
--- a/card/v2/common.go
+++ b/card/v2/common.go
@@ -23,6 +23,18 @@ func unmarshalComponent(data json.RawMessage) (Component, error) {
 		res := &ComponentColumnSet{}
 		err = json.Unmarshal(data, res)
 		return res, err
+	case "markdown":
+		res := &ComponentMarkdown{}
+		err = json.Unmarshal(data, res)
+		return res, err
+	case "input":
+		res := &ComponentInput{}
+		err = json.Unmarshal(data, res)
+		return res, err
+	case "button":
+		res := &ComponentButton{}
+		err = json.Unmarshal(data, res)
+		return res, err
 	}
 
 	return nil, nil


### PR DESCRIPTION
when marshal markdown/input/button component, unmarshal it will return nil.

```go
func unmarshalComponent(data json.RawMessage) (Component, error) {
	tag := new(unmarshalComponentTag)
	err := json.Unmarshal(data, tag)
	if err != nil {
		return nil, err
	}
	switch tag.Tag {
	case "img":
		res := &ComponentImage{}
		err = json.Unmarshal(data, res)
		return res, err
	case "hr":
		return &ComponentDivider{}, nil
	case "column_set":
		res := &ComponentColumnSet{}
		err = json.Unmarshal(data, res)
		return res, err
	case "markdown":
		res := &ComponentMarkdown{}
		err = json.Unmarshal(data, res)
		return res, err
	case "input":
		res := &ComponentInput{}
		err = json.Unmarshal(data, res)
		return res, err
	case "button":
		res := &ComponentButton{}
		err = json.Unmarshal(data, res)
		return res, err
	}

	return nil, nil
}
```