### PR TITLE
fix SheetContent when parsing floats with E notation

### DIFF
--- a/type_sheet_content.go
+++ b/type_sheet_content.go
@@ -154,7 +154,7 @@ func (r *SheetContent) UnmarshalJSON(bytes []byte) error {
 	} else if (bytes[0] >= '0' && bytes[0] <= '9') ||
 		(bytes[0] == '-' && len(bytes) > 1 && bytes[1] >= '0' && bytes[1] <= '9') {
 		str := string(bytes)
-		if strings.Contains(str, ".") {
+		if strings.ContainsAny(str, ".eE") {
 			float, err := strconv.ParseFloat(str, 64)
 			if err != nil {
 				return err


### PR DESCRIPTION
able to handle with numbers like `1E9`, `1e9`, `1E-9`, etc, which are possible to be returned b Lark server.